### PR TITLE
relax on tensorflow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 sphinx>=2.1.2
 networkx>=2.2
 setuptools>=40.8.0
-tensorflow==1.13.1
+tensorflow>=1.13.1,<2
 matplotlib>=3.0.3
 numpy>=1.16.2
 seaborn>=0.9.0


### PR DESCRIPTION
According to `README.md`, multiple versions of tensorflow would be good in most cases. I've tested it against version r1.14.0 and r1.15.0 in my working scenario. Should we let the version be in range >=1.13.1,<2 ?