### PR TITLE
Add inference for TransD, TransH, TransM and TransR models

### DIFF
--- a/pykg2vec/core/KGMeta.py
+++ b/pykg2vec/core/KGMeta.py
@@ -6,7 +6,7 @@ Knowledge Graph Meta Class
 It provides Abstract class for the Knowledge graph models.
 """
 
-from abc import ABCMeta
+from abc import ABCMeta, abstractmethod
 
 
 class ModelMeta:
@@ -18,26 +18,32 @@ class ModelMeta:
 		"""Initialize and create the model to be trained and inferred"""
 		pass
 
+	@abstractmethod
 	def def_inputs(self):
 		"""Function to define the inputs for the model"""
 		pass
 
+	@abstractmethod
 	def def_parameters(self):
 		"""Function to define the parameters for the model"""
 		pass
 
+	@abstractmethod
 	def def_loss(self):
 		"""Function to define how loss is calculated in the model"""
 		pass
-		
+
+	@abstractmethod
 	def embed(self,h, r, t):
 		"""Function to get the embedding value"""
 		pass
 
+	@abstractmethod
 	def get_embed(self,h, r, t):
 		"""Function to get the embedding value in numpy"""
 		pass
 
+	@abstractmethod
 	def get_proj_embed(self,h, r, t):
 		"""Function to get the projected embedding value"""
 		pass
@@ -51,18 +57,22 @@ class TrainerMeta:
 		"""Initializing and create the model to be trained and inferred"""
 		pass
 
+	@abstractmethod
 	def build_model(self):
 		"""function to compile the model"""
 		pass
 
+	@abstractmethod
 	def train_model(self):
 		"""function to train the model"""
 		pass
 
+	@abstractmethod
 	def save_model(self, sess):
 		"""function to save the model"""
 		pass
 
+	@abstractmethod
 	def load_model(self, sess):
 		"""function to load the model"""
 		pass
@@ -75,11 +85,13 @@ class VisualizationMeta:
 	def __init__(self):
 		"""Initializing and create the model to be trained and inferred"""
 		pass
-		
+
+	@abstractmethod
 	def display(self):
 		"""function to display embedding"""
 		pass
 
+	@abstractmethod
 	def summary(self):
 		"""function to print the summary"""
 		pass
@@ -92,22 +104,59 @@ class EvaluationMeta:
 	def __init__(self):
 		pass
 
+	@abstractmethod
 	def relation_prediction(self):
 		"""Function for evaluating link prediction"""
 		pass
 
+	@abstractmethod
 	def entity_classification(self):
 		"""Function for evaluating entity classification"""
 		pass
 
+	@abstractmethod
 	def relation_classification(self):
 		"""Function for evaluating relation classification"""
 		pass
 
+	@abstractmethod
 	def triple_classification(self):
 		"""Function for evaluating triple classificaiton"""
 		pass
 
+	@abstractmethod
 	def entity_completion(self):
 		"""Function for evaluating entity completion"""
+		pass
+
+class InferenceMeta:
+	""" Meta Class for inference based on distance measure"""
+	__metaclass__ = ABCMeta
+
+	def __init__(self):
+		pass
+
+	@abstractmethod
+	def def_parameters(self):
+		"""Function to define the parameters for the model"""
+		pass
+
+	@abstractmethod
+	def distance(self, h, r, t, axis):
+		"""Function to calculate distance measure in embedding space"""
+		pass
+
+	@abstractmethod
+	def infer_tails(self, h, r, topk):
+		"""Function to infer top k tails for given head and relation"""
+		pass
+
+	@abstractmethod
+	def infer_heads(self, r, t, topk):
+		"""Function to infer top k head for given relation and tail"""
+		pass
+
+	@abstractmethod
+	def infer_rels(self, h, t, topk):
+		"""Function to infer top k relations for given head and tail"""
 		pass

--- a/pykg2vec/core/TransD.py
+++ b/pykg2vec/core/TransD.py
@@ -6,10 +6,10 @@ from __future__ import print_function
 
 import tensorflow as tf
 
-from pykg2vec.core.KGMeta import ModelMeta
+from pykg2vec.core.KGMeta import ModelMeta, InferenceMeta
 
 
-class TransD(ModelMeta):
+class TransD(ModelMeta, InferenceMeta):
     """ `Knowledge Graph Embedding via Dynamic Mapping Matrix`_
 
         TransD constructs a dynamic mapping matrix for each entity-relation pair by considering the diversity of entities and relations simultaneously.
@@ -157,6 +157,72 @@ class TransD(ModelMeta):
         _, tail_rank = tf.nn.top_k(score_tail, k=num_total_ent)
 
         return head_rank, tail_rank
+
+    def infer_tails(self, h, r, topk):
+        """Function to infer top k tails for given head and relation.
+
+           Args:
+              h (int): Head entities ids.
+              r (int): Relation ids of the triple.
+              topk (int): Top K values to infer.
+
+            Returns:
+               Tensors: Returns the list of tails tensor.
+        """
+        norm_ent_embeddings = tf.nn.l2_normalize(self.ent_embeddings, axis=1)
+        norm_rel_embeddings = tf.nn.l2_normalize(self.rel_embeddings, axis=1)
+
+        head_vec = tf.nn.embedding_lookup(norm_ent_embeddings, h)
+        rel_vec = tf.nn.embedding_lookup(norm_rel_embeddings, r)
+
+        score_tail = self.distance(head_vec, rel_vec, norm_ent_embeddings, axis=1)
+        _, tails = tf.nn.top_k(-score_tail, k=topk)
+
+        return tails
+
+    def infer_heads(self, r, t, topk):
+        """Function to infer top k head for given relation and tail.
+
+           Args:
+              t (int): tail entities ids.
+              r (int): Relation ids of the triple.
+              topk (int): Top K values to infer.
+
+            Returns:
+               Tensors: Returns the list of heads tensor.
+        """
+        norm_ent_embeddings = tf.nn.l2_normalize(self.ent_embeddings, axis=1)
+        norm_rel_embeddings = tf.nn.l2_normalize(self.rel_embeddings, axis=1)
+
+        tail_vec = tf.nn.embedding_lookup(norm_ent_embeddings, t)
+        rel_vec = tf.nn.embedding_lookup(norm_rel_embeddings, r)
+
+        score_head = self.distance(norm_ent_embeddings, rel_vec, tail_vec, axis=1)
+        _, heads = tf.nn.top_k(-score_head, k=topk)
+
+        return heads
+
+    def infer_rels(self, h, t, topk):
+        """Function to infer top k relations for given head and tail.
+
+           Args:
+              h (int): Head entities ids.
+              t (int): Tail entities ids.
+              topk (int): Top K values to infer.
+
+            Returns:
+               Tensors: Returns the list of rels tensor.
+        """
+        norm_ent_embeddings = tf.nn.l2_normalize(self.ent_embeddings, axis=1)
+        norm_rel_embeddings = tf.nn.l2_normalize(self.rel_embeddings, axis=1)
+
+        head_vec = tf.nn.embedding_lookup(norm_ent_embeddings, h)
+        tail_vec = tf.nn.embedding_lookup(norm_ent_embeddings, t)
+
+        score_rel = self.distance(head_vec, norm_rel_embeddings, tail_vec, axis=1)
+        _, rels = tf.nn.top_k(-score_rel, k=topk)
+
+        return rels
 
     def distance(self, h, r, t, axis=1):
         """Function to calculate distance measure in embedding space.

--- a/pykg2vec/core/TransE.py
+++ b/pykg2vec/core/TransE.py
@@ -6,10 +6,10 @@ from __future__ import print_function
 
 import tensorflow as tf
 
-from pykg2vec.core.KGMeta import ModelMeta
+from pykg2vec.core.KGMeta import ModelMeta, InferenceMeta
 
 
-class TransE(ModelMeta):
+class TransE(ModelMeta, InferenceMeta):
     """ `Translating Embeddings for Modeling Multi-relational Data`_
 
         TransE is an energy based model which represents the
@@ -127,7 +127,7 @@ class TransE(ModelMeta):
 
         return head_rank, tail_rank
 
-    def infer_tails(self,h,r, topk ):
+    def infer_tails(self, h, r, topk):
         """Function to infer top k tails for given head and relation.
 
            Args:
@@ -144,12 +144,12 @@ class TransE(ModelMeta):
         head_vec = tf.nn.embedding_lookup(norm_ent_embeddings, h)
         rel_vec = tf.nn.embedding_lookup(norm_rel_embeddings, r)
 
-        score_tail = self.distance(head_vec,rel_vec, norm_ent_embeddings, axis=1)
-        _, tails= tf.nn.top_k(-score_tail, k=topk)
+        score_tail = self.distance(head_vec, rel_vec, norm_ent_embeddings, axis=1)
+        _, tails = tf.nn.top_k(-score_tail, k=topk)
 
         return tails
 
-    def infer_heads(self,r,t, topk ):
+    def infer_heads(self, r, t, topk):
         """Function to infer top k head for given relation and tail.
 
            Args:
@@ -167,7 +167,7 @@ class TransE(ModelMeta):
         rel_vec = tf.nn.embedding_lookup(norm_rel_embeddings, r)
 
         score_head = self.distance(norm_ent_embeddings, rel_vec, tail_vec, axis=1)
-        _, heads= tf.nn.top_k(-score_head, k=topk)
+        _, heads = tf.nn.top_k(-score_head, k=topk)
 
         return heads
 

--- a/pykg2vec/core/TransH.py
+++ b/pykg2vec/core/TransH.py
@@ -6,10 +6,10 @@ from __future__ import print_function
 
 import tensorflow as tf
 
-from pykg2vec.core.KGMeta import ModelMeta
+from pykg2vec.core.KGMeta import ModelMeta, InferenceMeta
 
 
-class TransH(ModelMeta):
+class TransH(ModelMeta, InferenceMeta):
     """ `Knowledge Graph Embedding by Translating on Hyperplanes`_
 
         TransH models a relation as a hyperplane together with a translation operation on it.
@@ -146,6 +146,72 @@ class TransH(ModelMeta):
         _, tail_rank = tf.nn.top_k(score_tail, k=num_entity)
 
         return head_rank, tail_rank
+
+    def infer_tails(self, h, r, topk):
+        """Function to infer top k tails for given head and relation.
+
+           Args:
+              h (int): Head entities ids.
+              r (int): Relation ids of the triple.
+              topk (int): Top K values to infer.
+
+            Returns:
+               Tensors: Returns the list of tails tensor.
+        """
+        norm_ent_embeddings = tf.nn.l2_normalize(self.ent_embeddings, axis=1)
+        norm_rel_embeddings = tf.nn.l2_normalize(self.rel_embeddings, axis=1)
+
+        head_vec = tf.nn.embedding_lookup(norm_ent_embeddings, h)
+        rel_vec = tf.nn.embedding_lookup(norm_rel_embeddings, r)
+
+        score_tail = self.distance(head_vec, rel_vec, norm_ent_embeddings, axis=1)
+        _, tails = tf.nn.top_k(-score_tail, k=topk)
+
+        return tails
+
+    def infer_heads(self, r, t, topk):
+        """Function to infer top k head for given relation and tail.
+
+           Args:
+              t (int): tail entities ids.
+              r (int): Relation ids of the triple.
+              topk (int): Top K values to infer.
+
+            Returns:
+               Tensors: Returns the list of heads tensor.
+        """
+        norm_ent_embeddings = tf.nn.l2_normalize(self.ent_embeddings, axis=1)
+        norm_rel_embeddings = tf.nn.l2_normalize(self.rel_embeddings, axis=1)
+
+        tail_vec = tf.nn.embedding_lookup(norm_ent_embeddings, t)
+        rel_vec = tf.nn.embedding_lookup(norm_rel_embeddings, r)
+
+        score_head = self.distance(norm_ent_embeddings, rel_vec, tail_vec, axis=1)
+        _, heads = tf.nn.top_k(-score_head, k=topk)
+
+        return heads
+
+    def infer_rels(self, h, t, topk):
+        """Function to infer top k relations for given head and tail.
+
+           Args:
+              h (int): Head entities ids.
+              t (int): Tail entities ids.
+              topk (int): Top K values to infer.
+
+            Returns:
+               Tensors: Returns the list of rels tensor.
+        """
+        norm_ent_embeddings = tf.nn.l2_normalize(self.ent_embeddings, axis=1)
+        norm_rel_embeddings = tf.nn.l2_normalize(self.rel_embeddings, axis=1)
+
+        head_vec = tf.nn.embedding_lookup(norm_ent_embeddings, h)
+        tail_vec = tf.nn.embedding_lookup(norm_ent_embeddings, t)
+
+        score_rel = self.distance(head_vec, norm_rel_embeddings, tail_vec, axis=1)
+        _, rels = tf.nn.top_k(-score_rel, k=topk)
+
+        return rels
 
     def get_proj(self, r):
         """Calculates the projection of r"""

--- a/pykg2vec/core/TransR.py
+++ b/pykg2vec/core/TransR.py
@@ -7,10 +7,10 @@ from __future__ import print_function
 import tensorflow as tf
 import numpy as np
 
-from pykg2vec.core.KGMeta import ModelMeta
+from pykg2vec.core.KGMeta import ModelMeta, InferenceMeta
 
 
-class TransR(ModelMeta):
+class TransR(ModelMeta, InferenceMeta):
     """ `Learning Entity and Relation Embeddings for Knowledge Graph Completion`_
 
         TranR is a translation based knowledge graph embedding method. Similar to TransE and TransH, it also
@@ -150,6 +150,72 @@ class TransR(ModelMeta):
         _, tail_rank = tf.nn.top_k(score_tail, k=num_total_ent)
 
         return head_rank, tail_rank
+
+    def infer_tails(self, h, r, topk):
+        """Function to infer top k tails for given head and relation.
+
+           Args:
+              h (int): Head entities ids.
+              r (int): Relation ids of the triple.
+              topk (int): Top K values to infer.
+
+            Returns:
+               Tensors: Returns the list of tails tensor.
+        """
+        norm_ent_embeddings = tf.nn.l2_normalize(self.ent_embeddings, axis=1)
+        norm_rel_embeddings = tf.nn.l2_normalize(self.rel_embeddings, axis=1)
+
+        head_vec = tf.nn.embedding_lookup(norm_ent_embeddings, h)
+        rel_vec = tf.nn.embedding_lookup(norm_rel_embeddings, r)
+
+        score_tail = self.distance(head_vec, rel_vec, norm_ent_embeddings, axis=1)
+        _, tails = tf.nn.top_k(-score_tail, k=topk)
+
+        return tails
+
+    def infer_heads(self, r, t, topk):
+        """Function to infer top k head for given relation and tail.
+
+           Args:
+              t (int): tail entities ids.
+              r (int): Relation ids of the triple.
+              topk (int): Top K values to infer.
+
+            Returns:
+               Tensors: Returns the list of heads tensor.
+        """
+        norm_ent_embeddings = tf.nn.l2_normalize(self.ent_embeddings, axis=1)
+        norm_rel_embeddings = tf.nn.l2_normalize(self.rel_embeddings, axis=1)
+
+        tail_vec = tf.nn.embedding_lookup(norm_ent_embeddings, t)
+        rel_vec = tf.nn.embedding_lookup(norm_rel_embeddings, r)
+
+        score_head = self.distance(norm_ent_embeddings, rel_vec, tail_vec, axis=1)
+        _, heads = tf.nn.top_k(-score_head, k=topk)
+
+        return heads
+
+    def infer_rels(self, h, t, topk):
+        """Function to infer top k relations for given head and tail.
+
+           Args:
+              h (int): Head entities ids.
+              t (int): Tail entities ids.
+              topk (int): Top K values to infer.
+
+            Returns:
+               Tensors: Returns the list of rels tensor.
+        """
+        norm_ent_embeddings = tf.nn.l2_normalize(self.ent_embeddings, axis=1)
+        norm_rel_embeddings = tf.nn.l2_normalize(self.rel_embeddings, axis=1)
+
+        head_vec = tf.nn.embedding_lookup(norm_ent_embeddings, h)
+        tail_vec = tf.nn.embedding_lookup(norm_ent_embeddings, t)
+
+        score_rel = self.distance(head_vec, norm_rel_embeddings, tail_vec, axis=1)
+        _, rels = tf.nn.top_k(-score_rel, k=topk)
+
+        return rels
 
     def transform(self, matrix, embeddings):
         """Performs transformation of the embeddings into relation space.

--- a/pykg2vec/test/test_inference.py
+++ b/pykg2vec/test/test_inference.py
@@ -53,7 +53,11 @@ def testing_function_with_args(name, distance_measure=None, bilinear=None, displ
 
     trainer.exit_interactive_mode()
 
-def test_inference_transE_args():
-    """Function to test TransE Algorithm with arguments."""
-    testing_function_with_args('transe')
 
+def test_inference_transE_args():
+    """Function to test Algorithms with arguments."""
+    testing_function_with_args('transd')
+    testing_function_with_args('transe')
+    testing_function_with_args('transh')
+    testing_function_with_args('transm')
+    testing_function_with_args('transr')


### PR DESCRIPTION
This PR added inferencing capabilities based on the distance measure for all the TransX models except TransG which currently has no `distance()` defined. At the moment, TransX models duplicate the `infer_x()` methods and according to the DRY principle, they could be moved up to the abstract class in KGMeta.py and shared between model classes. In the future, the implementations of `infer_x()`s in different models may diverse so I refrained myself there. Thanks!