### PR TITLE
fix the issue on keras model inheritance and improve the tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+branch = True
+concurrency = multiprocessing
+source = pykg2vec
+parallel = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,15 @@ os:
 python:
   - "3.6"
 
+env:
+  - COVERAGE_RCFILE=".coveragerc"
+
 install:
   - pip install -r requirements.txt
   - pip install .
   - pip uninstall -y bson && pip install pymongo
   - pip install 'pytest>=3.6'
-  - pip install pytest-cov coverage coveralls
+  - pip install -r requirements-dev.txt
 
 script:
   - pytest --disable-pytest-warnings --cov pykg2vec

--- a/pykg2vec/core/Complex.py
+++ b/pykg2vec/core/Complex.py
@@ -102,7 +102,7 @@ class Complex(ModelMeta):
 
         return loss
 
-    def predict(self, h, r, t, topk=-1):
+    def predict_rank(self, h, r, t, topk=-1):
         """Function that performs prediction for TransE. 
            shape of h can be either [num_tot_entity] or [1]. 
            shape of t can be either [num_tot_entity] or [1].

--- a/pykg2vec/core/ConvE.py
+++ b/pykg2vec/core/ConvE.py
@@ -155,7 +155,7 @@ class ConvE(ModelMeta):
 
         return loss
 
-    def predict_tail(self, e, r, topk=-1):
+    def predict_tail_rank(self, e, r, topk=-1):
         h_emb = tf.nn.embedding_lookup(self.ent_embeddings, e)
         r_emb = tf.nn.embedding_lookup(self.rel_embeddings, r)
 
@@ -169,7 +169,7 @@ class ConvE(ModelMeta):
 
         return rank
 
-    def predict_head(self, e, r, topk=-1):
+    def predict_head_rank(self, e, r, topk=-1):
         t_emb = tf.nn.embedding_lookup(self.ent_embeddings, e)
         r_emb = tf.nn.embedding_lookup(self.rel_embeddings, r)
 
@@ -180,5 +180,19 @@ class ConvE(ModelMeta):
         pred_heads = -self.forward(stacked_tr, 1)
 
         _, rank = tf.nn.top_k(pred_heads, k=topk)
+
+        return rank
+
+    def predict_rel_rank(self, e, r, topk=-1):
+        h_emb = tf.nn.embedding_lookup(self.ent_embeddings, e)
+        t_emb = tf.nn.embedding_lookup(self.ent_embeddings, e)
+
+        stacked_h = tf.reshape(h_emb, [-1, 1, 10, 20])
+        stacked_t = tf.reshape(t_emb, [-1, 1, 10, 20])
+
+        stacked_ht = tf.concat([stacked_h, stacked_t], 1)
+        pred_rels = -self.forward(stacked_ht, 1)
+
+        _, rank = tf.nn.top_k(pred_rels, k=topk)
 
         return rank

--- a/pykg2vec/core/ConvKB.py
+++ b/pykg2vec/core/ConvKB.py
@@ -109,7 +109,7 @@ class ConvKB(ModelMeta):
 
         return loss
 
-    def predict(self, h, r, t, topk=-1):
+    def predict_rank(self, h, r, t, topk=-1):
         """Function that performs prediction for TransE. 
            shape of h can be either [num_tot_entity] or [1]. 
            shape of t can be either [num_tot_entity] or [1].

--- a/pykg2vec/core/DistMult.py
+++ b/pykg2vec/core/DistMult.py
@@ -122,7 +122,7 @@ class DistMult(ModelMeta):
 
         return loss
 
-    def predict(self, h, r, t, topk=-1):
+    def predict_rank(self, h, r, t, topk=-1):
         """Function that performs prediction for TransE. 
            shape of h can be either [num_tot_entity] or [1]. 
            shape of t can be either [num_tot_entity] or [1].

--- a/pykg2vec/core/HoLE.py
+++ b/pykg2vec/core/HoLE.py
@@ -128,7 +128,7 @@ class HoLE(ModelMeta):
         emb_t = tf.nn.embedding_lookup(norm_ent_embeddings, t)
         return emb_h, emb_r, emb_t
 
-    def predict(self, h, r, t, topk=-1):
+    def predict_rank(self, h, r, t, topk=-1):
         """Function that performs prediction for TransE. 
            shape of h can be either [num_tot_entity] or [1]. 
            shape of t can be either [num_tot_entity] or [1].

--- a/pykg2vec/core/KG2E.py
+++ b/pykg2vec/core/KG2E.py
@@ -99,7 +99,7 @@ class KG2E(ModelMeta):
 
         return loss
 
-    def predict(self, h, r, t, topk=-1):
+    def predict_rank(self, h, r, t, topk=-1):
         """Function that performs prediction for TransE. 
            shape of h can be either [num_tot_entity] or [1]. 
            shape of t can be either [num_tot_entity] or [1].
@@ -216,7 +216,7 @@ class KG2E_EL(KG2E):
 
         return loss
 
-    def predict(self, h, r, t, topk=-1):
+    def predict_rank(self, h, r, t, topk=-1):
         """Function that performs prediction for TransE. 
            shape of h can be either [num_tot_entity] or [1]. 
            shape of t can be either [num_tot_entity] or [1].

--- a/pykg2vec/core/NTN.py
+++ b/pykg2vec/core/NTN.py
@@ -150,7 +150,7 @@ class NTN(ModelMeta):
         regul = tf.sqrt(sum([tf.reduce_sum(tf.square(var)) for var in self.parameter_list]))
         return loss + self.config.lmbda*regul
 
-    def predict(self, h, r, t, topk=-1):
+    def predict_rank(self, h, r, t, topk=-1):
         """Function that performs prediction for TransE. 
            shape of h can be either [num_tot_entity] or [1]. 
            shape of t can be either [num_tot_entity] or [1].

--- a/pykg2vec/core/Rescal.py
+++ b/pykg2vec/core/Rescal.py
@@ -118,7 +118,7 @@ class Rescal(ModelMeta):
         loss = tf.reduce_sum(tf.maximum(neg_score + self.config.margin - pos_score, 0))
         return loss
 
-    def predict(self, h, r, t, topk=-1):
+    def predict_rank(self, h, r, t, topk=-1):
         """Function that performs prediction for TransE. 
            shape of h can be either [num_tot_entity] or [1]. 
            shape of t can be either [num_tot_entity] or [1].

--- a/pykg2vec/core/RotatE.py
+++ b/pykg2vec/core/RotatE.py
@@ -128,7 +128,7 @@ class RotatE(ModelMeta):
 
         return loss
 
-    def predict(self, h, r, t, topk=-1):
+    def predict_rank(self, h, r, t, topk=-1):
         """Function that performs prediction for TransE. 
            shape of h can be either [num_tot_entity] or [1]. 
            shape of t can be either [num_tot_entity] or [1].

--- a/pykg2vec/core/SLM.py
+++ b/pykg2vec/core/SLM.py
@@ -117,7 +117,7 @@ class SLM(ModelMeta):
         mr2t = tf.matmul(t, self.mr2) # t => [m, d], self.mr2 => [d, k]
         return tf.tanh(mr1h + mr2t)
 
-    def predict(self, h, r, t, topk=-1):
+    def predict_rank(self, h, r, t, topk=-1):
         """Function that performs prediction for TransE. 
            shape of h can be either [num_tot_entity] or [1]. 
            shape of t can be either [num_tot_entity] or [1].

--- a/pykg2vec/core/SME.py
+++ b/pykg2vec/core/SME.py
@@ -156,7 +156,7 @@ class SME(ModelMeta):
 
         return loss
 
-    def predict(self, h, r, t, topk=-1):
+    def predict_rank(self, h, r, t, topk=-1):
         """Function that performs prediction for TransE. 
            shape of h can be either [num_tot_entity] or [1]. 
            shape of t can be either [num_tot_entity] or [1].

--- a/pykg2vec/core/TransD.py
+++ b/pykg2vec/core/TransD.py
@@ -136,7 +136,7 @@ class TransD(ModelMeta):
 
         return loss
 
-    def predict(self, h, r, t, topk=-1):
+    def predict_rank(self, h, r, t, topk=-1):
         """Function that performs prediction for TransE. 
            shape of h can be either [num_tot_entity] or [1]. 
            shape of t can be either [num_tot_entity] or [1].

--- a/pykg2vec/core/TransE.py
+++ b/pykg2vec/core/TransE.py
@@ -125,7 +125,7 @@ class TransE(ModelMeta):
 
         return loss
 
-    def predict(self, h, r, t, topk=-1):
+    def predict_rank(self, h, r, t, topk=-1):
         """Function that performs prediction for TransE. 
            shape of h can be either [num_tot_entity] or [1]. 
            shape of t can be either [num_tot_entity] or [1].

--- a/pykg2vec/core/TransH.py
+++ b/pykg2vec/core/TransH.py
@@ -151,7 +151,7 @@ class TransH(ModelMeta):
 
         return self.config.C * (term1 + term2)
 
-    def predict(self, h, r, t, topk=-1):
+    def predict_rank(self, h, r, t, topk=-1):
         """Function that performs prediction for TransH. 
            shape of h can be either [num_tot_entity] or [1]. 
            shape of t can be either [num_tot_entity] or [1].

--- a/pykg2vec/core/TransM.py
+++ b/pykg2vec/core/TransM.py
@@ -136,7 +136,7 @@ class TransM(ModelMeta):
 
         return loss
 
-    def predict(self, h, r, t, topk=-1):
+    def predict_rank(self, h, r, t, topk=-1):
         """Function that performs prediction for TransE. 
            shape of h can be either [num_tot_entity] or [1]. 
            shape of t can be either [num_tot_entity] or [1].

--- a/pykg2vec/core/TransR.py
+++ b/pykg2vec/core/TransR.py
@@ -145,7 +145,7 @@ class TransR(ModelMeta):
 
         return loss
 
-    def predict(self, h, r, t, topk=-1):
+    def predict_rank(self, h, r, t, topk=-1):
 
         """Function that performs prediction for TransE. 
            shape of h can be either [num_tot_entity] or [1]. 

--- a/pykg2vec/core/TuckER.py
+++ b/pykg2vec/core/TuckER.py
@@ -123,7 +123,7 @@ class TuckER(ModelMeta):
 
         return loss
 
-    def predict_tail(self, e, r, topk=-1):
+    def predict_tail_rank(self, e, r, topk=-1):
         # import pdb; pdb.set_trace()
         e = tf.reshape(e, [-1])
         r = tf.reshape(r, [-1])
@@ -131,5 +131,5 @@ class TuckER(ModelMeta):
         _, rank = tf.nn.top_k(-predictions, k=topk)
         return rank
 
-    def predict_head(self, e, r, topk=-1):
-        return self.predict_tail(e, r, topk=topk)
+    def predict_head_rank(self, e, r, topk=-1):
+        return self.predict_tail_rank(e, r, topk=topk)

--- a/pykg2vec/test/test_inference.py
+++ b/pykg2vec/test/test_inference.py
@@ -5,7 +5,7 @@ This module is for testing unit functions of model
 """
 import pytest
 
-from pykg2vec.config.config import *
+from pykg2vec.config.config import KGEArgParser, Importer
 from pykg2vec.utils.trainer import Trainer
 from pykg2vec.utils.kgcontroller import KnowledgeGraph
 
@@ -15,15 +15,15 @@ def testing_function_with_args(name, l1_flag, distance_measure=None, bilinear=No
     """Function to test the models with arguments."""
     # getting the customized configurations from the command-line arguments.
     args = KGEArgParser().get_args([])
-    
+
     # Preparing data and cache the data for later usage
     knowledge_graph = KnowledgeGraph(dataset=args.dataset_name)
     knowledge_graph.prepare_data()
-    
+
     # Extracting the corresponding model config and definition from Importer().
     config_def, model_def = Importer().import_model_config(name)
     config = config_def(args=args)
-    
+
     config.epochs     = 1
     config.test_step  = 1
     config.test_num   = 10
@@ -31,7 +31,7 @@ def testing_function_with_args(name, l1_flag, distance_measure=None, bilinear=No
     config.save_model = True
     config.L1_flag = l1_flag
     config.debug = True
-    
+
     model = model_def(config)
 
     # Create, Compile and Train the model. While training, several evaluation will be performed.
@@ -56,22 +56,31 @@ def testing_function_with_args(name, l1_flag, distance_measure=None, bilinear=No
 
     trainer.exit_interactive_mode()
 
-@pytest.mark.parametrize("model_name", ['transd', 'transe', 'transh', 'transm', 'transr', 'distmult', 'slm', 'sme'])
-def test_inference_transE_args(model_name):
+@pytest.mark.parametrize("model_name", [
+    'complex',
+    'complexn3',
+    # 'conve',
+    # 'convkb',
+    'distmult',
+    'hole',
+    'kg2e',
+    'kg2e_el',
+    'ntn',
+    'proje_pointwise',
+    'rotate',
+    'rescal',
+    'slm',
+    'sme',
+    'transd',
+    'transe',
+    # 'transg',
+    'transh',
+    'transm',
+    'transr',
+    # 'tucker',
+])
+def test_inference(model_name):
     """Function to test Algorithms with arguments."""
     testing_function_with_args(model_name, True)
-    # testing_function_with_args('transe', True)
-    # testing_function_with_args('transh', True)
-    # testing_function_with_args('transm', True)
-    # testing_function_with_args('transr', True)
-    # testing_function_with_args('conve', True)
-    # testing_function_with_args('convkb', True)
-    # testing_function_with_args('distmult', True)
-    # testing_function_with_args('ntn', True)
-    # testing_function_with_args('proje_pointwise', True)
-    # testing_function_with_args('slm', True)
-    # testing_function_with_args('sme', True)
-    # testing_function_with_args('hole', True)
-    # testing_function_with_args('complex', True)
-    # testing_function_with_args('rotate', True)
-    # testing_function_with_args('tucker', True)
+
+

--- a/pykg2vec/test/test_trainer.py
+++ b/pykg2vec/test/test_trainer.py
@@ -10,13 +10,13 @@ from pykg2vec.utils.trainer import Trainer, Monitor
 from pykg2vec.utils.kgcontroller import KnowledgeGraph
 
 @pytest.mark.skip(reason="This is a functional method.")
-def get_model(result_path_dir, configured_epochs, patience, early_stop_epoch):
+def get_model(result_path_dir, configured_epochs, patience, early_stop_epoch, config_key):
     args = KGEArgParser().get_args([])
 
     knowledge_graph = KnowledgeGraph(dataset="Freebase15k")
     knowledge_graph.prepare_data()
 
-    config_def, model_def = Importer().import_model_config("complex")
+    config_def, model_def = Importer().import_model_config(config_key)
     config = config_def(args=args)
 
     config.epochs = configured_epochs
@@ -31,10 +31,12 @@ def get_model(result_path_dir, configured_epochs, patience, early_stop_epoch):
 
     return model_def(config)
 
-def test_full_epochs(tmpdir):
+@pytest.mark.parametrize("config_key",
+                         filter(lambda x: x != "conve" and x != "convkb" and x != "transg", list(Importer().configMap.keys())))
+def test_full_epochs(tmpdir, config_key):
     result_path_dir = tmpdir.mkdir("result_path")
     configured_epochs = 10
-    model = get_model(result_path_dir, configured_epochs, -1, 5)
+    model = get_model(result_path_dir, configured_epochs, -1, 5, config_key)
 
     trainer = Trainer(model=model)
     trainer.build_model()
@@ -45,7 +47,7 @@ def test_full_epochs(tmpdir):
 def test_early_stopping_on_loss(tmpdir):
     result_path_dir = tmpdir.mkdir("result_path")
     configured_epochs = 10
-    model = get_model(result_path_dir, configured_epochs, 1, 1)
+    model = get_model(result_path_dir, configured_epochs, 1, 1, "complex")
 
     trainer = Trainer(model=model)
     trainer.build_model()
@@ -70,7 +72,7 @@ def test_early_stopping_on_loss(tmpdir):
 def test_early_stopping_on_ranks(tmpdir, monitor):
     result_path_dir = tmpdir.mkdir("result_path")
     configured_epochs = 10
-    model = get_model(result_path_dir, configured_epochs, 0, 1)
+    model = get_model(result_path_dir, configured_epochs, 0, 1, "complex")
 
     trainer = Trainer(model=model)
     trainer.build_model()
@@ -81,7 +83,7 @@ def test_early_stopping_on_ranks(tmpdir, monitor):
 def test_throw_exception_on_unknown_monitor(tmpdir):
     result_path_dir = tmpdir.mkdir("result_path")
     configured_epochs = 10
-    model = get_model(result_path_dir, configured_epochs, 0, 1)
+    model = get_model(result_path_dir, configured_epochs, 0, 1, "complex")
 
     trainer = Trainer(model=model)
     trainer.build_model()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+coverage>=5.0.4
+coveralls>=1.11.1
+pytest-cov>=2.8.1


### PR DESCRIPTION
After inheriting from `tf.keras.Model`, pykg2vec models have `predict()` automatically. However, some models introduced their own masking `predict()` methods and some did not, which makes the behaviour unpredictable when calling `self.model.predict()` in evaluator. This PR renames `predict` to `predict_rank` and `predict_xxx` to `predict_xxx_rank` in each model. It also makes coveragepy configurable and improves the coverage on inference.