### PR TITLE
wrap training, tuning and inferring examples into command-line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,62 +49,50 @@ For beginners, these papers, [A Review of Relational Machine Learning for Knowle
 The documentation is [here](https://pykg2vec.readthedocs.io/). 
 
 ## Usage Examples
-With pykg2vec, you can 
+With pykg2vec command-line interface, you can
 1. Run a single algorithm with various models and datasets (customized dataset also supported).
-2. Tune a single algorithm. 
+    ```
+    # Check all tunnable parameters.
+    (pykg2vec) $ pykg2vec-train -h
+
+    # Train TransE on FB15k benchmark dataset.
+    (pykg2vec) $ pykg2vec-train -mn TransE
+
+    # Train using different KGE methods.
+    (pykg2vec) $ pykg2vec-train -mn [TransE|TransD|TransH|TransG|TransM|TransR|Complex|ComplexN3|CP|RotatE|Analogy|
+                           DistMult|KG2E|KG2E_EL|NTN|Rescal|SLM|SME|SME_BL|HoLE|ConvE|ConvKB|Proje_pointwise]
+
+    # For KGE using projection-based loss function, use more processes for batch generation.
+    (pykg2vec) $ pykg2vec-train -mn [ConvE|ConvKB|Proje_pointwise] -npg [the number of processes, 4 or 6]
+
+    # Train TransE model using different benchmark datasets.
+    (pykg2vec) $ pykg2vec-train -mn TransE -ds [fb15k|wn18|wn18_rr|yago3_10|fb15k_237|ks|nations|umls|dl50a|nell_955]
+
+    # Train TransE model using your own hyperparameters.
+    (pykg2vec) $ pykg2vec-train -exp True -mn TransE -ds fb15k -hpf ./examples/custom_hp.yaml
+
+    # Use your own dataset
+    (pykg2vec) $ pykg2vec-train -mn TransE -ds [name] -dsp [path to the custom dataset]
+    ```
+2. Tune a single algorithm.
+    ```
+    # Tune TransE using the benchmark dataset.
+    (pykg2vec) $ pykg2vec-tune -mn [TransE] -ds [dataset name]
+
+    # Tune TransE with your own search space
+    (pykg2vec) $ pykg2vec-tune -exp True -mn TransE -ds fb15k -ssf ./examples/custom_ss.yaml
+    ```
 3. Perform Inference Tasks (more advanced).
+    ```
+    # Train a model and perform inference tasks.
+    (pykg2vec) $ pykg2vec-infer -mn TransE
 
-We pasted one programming example (train.py) as below, 
-```python
-from pykg2vec.data.kgcontroller import KnowledgeGraph
-from pykg2vec.common import Importer, KGEArgParser
-from pykg2vec.utils.trainer import Trainer
+    # Perform inference tasks over a pretrained model.
+    (pykg2vec) $ pykg2vec-infer -mn TransE -ld [path to the pretrained model]
+    ```
+\* NB: On Windows, use `pykg2vec-train.py`, `pykg2vec-tune.py` and `pykg2vec-infer.py` instead.
 
-def main():
-    # getting the customized configurations from the command-line arguments.
-    args = KGEArgParser().get_args(sys.argv[1:])
-    
-    # Preparing data and cache the data for later usage
-    knowledge_graph = KnowledgeGraph(dataset=args.dataset_name, custom_dataset_path=args.dataset_path)
-    knowledge_graph.prepare_data()
-
-    # Extracting the corresponding model config and definition from Importer().
-    config_def, model_def = Importer().import_model_config(args.model_name.lower())
-    config = config_def(args)
-    model = model_def(**config.__dict__)
-
-    # Create, Compile and Train the model. While training, several evaluation will be performed.
-    trainer = Trainer(model, config)
-    trainer.build_model()
-    trainer.train_model()
-
-if __name__ == "__main__":
-    main()
-```
-With train.py you can try KGE methods using the following commands: 
-```bash
-# check all tunnable parameters.
-$ python train.py -h 
-
-# Train TransE on FB15k benchmark dataset.
-$ python train.py -mn TransE
-
-# Train using different KGE methods.
-$ python train.py -mn [TransE|TransD|TransH|TransG|TransM|TransR|Complex|ComplexN3|CP|RotatE|Analogy|
-                       DistMult|KG2E|KG2E_EL|NTN|Rescal|SLM|SME|SME_BL|HoLE|ConvE|ConvKB|Proje_pointwise]
-
-# For KGE using projection-based loss function, use more processes for batch generation.
-$ python train.py -mn [ConvE|ConvKB|Proje_pointwise] -npg [the number of processes, 4 or 6]
-
-# Train TransE model using different benchmark datasets.
-$ python train.py -mn TransE -ds [fb15k|wn18|wn18_rr|yago3_10|fb15k_237|ks|nations|umls|dl50a|nell_955]
-
-# Train TransE model using different hyperparameters.
-$ python train.py -exp True -mn TransE -ds fb15k -hpf ./examples/custom_hp.yaml
-
-```
-
-For more other pykg2vec usage, please check the [programming examples](https://pykg2vec.readthedocs.io/en/latest/auto_examples/index.html).
+For more usage of pykg2vec APIs, please check the [programming examples](https://pykg2vec.readthedocs.io/en/latest/auto_examples/index.html).
 
 ## Citation
 Please kindly consider citing our paper if you find pykg2vec useful for your research. 

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -46,9 +46,8 @@ All dependent packages (requirements.txt_) will be installed automatically when 
 
 4. **Validate the Installation**: try the examples under /examples folder. ::
 
-    (pykg2vec) $ cd ./examples
-    # train TransE using benchmark dataset fb15k
-    (pykg2vec) $ python train.py -mn transe -ds fb15k
+    # train TransE using benchmark dataset fb15k (use pykg2vec-train.py on Windows)
+    (pykg2vec) $ pykg2vec-train -mn transe -ds fb15k
 
 .. _GitHub: https://github.com/Sujit-O/pykg2vec/pulls
 .. _pytorch: https://pytorch.org/

--- a/scripts/pykg2vec-infer.py
+++ b/scripts/pykg2vec-infer.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sys
+
+from pykg2vec.common import Importer, KGEArgParser
+from pykg2vec.utils.trainer import Trainer
+
+
+def main(cmd_args):
+    args = KGEArgParser().get_args(cmd_args)
+
+    config_def, model_def = Importer().import_model_config(args.model_name.lower())
+    config = config_def(args)
+    model = model_def(**config.__dict__)
+
+    trainer = Trainer(model, config)
+    trainer.build_model()
+
+    trainer.infer_tails(1, 10, topk=5)
+    trainer.infer_heads(10, 20, topk=5)
+    trainer.infer_rels(1, 20, topk=5)
+
+
+if __name__ == "__main__":
+    __spec__ = None
+    main(sys.argv[1:])

--- a/scripts/pykg2vec-train.py
+++ b/scripts/pykg2vec-train.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sys
+
+from pykg2vec.data.kgcontroller import KnowledgeGraph
+from pykg2vec.common import Importer, KGEArgParser
+from pykg2vec.utils.trainer import Trainer
+
+
+def main(cmd_args):
+    args = KGEArgParser().get_args(cmd_args)
+
+    knowledge_graph = KnowledgeGraph(dataset=args.dataset_name)
+    knowledge_graph.prepare_data()
+
+    config_def, model_def = Importer().import_model_config(args.model_name.lower())
+    config = config_def(args)
+    model = model_def(**config.__dict__)
+
+    trainer = Trainer(model, config)
+    trainer.build_model()
+    trainer.train_model()
+
+
+if __name__ == "__main__":
+    __spec__ = None
+    main(sys.argv[1:])
+

--- a/scripts/pykg2vec-tune.py
+++ b/scripts/pykg2vec-tune.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sys
+
+from pykg2vec.common import KGEArgParser
+from pykg2vec.utils.bayesian_optimizer import BaysOptimizer
+
+
+def main(cmd_args):
+    args = KGEArgParser().get_args(cmd_args)
+
+    bays_opt = BaysOptimizer(args=args)
+
+    bays_opt.optimize()
+
+
+if __name__ == "__main__":
+    __spec__ = None
+    main(sys.argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -37,4 +37,9 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
+    scripts=[
+        "scripts/pykg2vec-train.py",
+        "scripts/pykg2vec-infer.py",
+        "scripts/pykg2vec-tune.py"
+    ],
 )


### PR DESCRIPTION
This PR aims at improving the experience raised by https://github.com/Sujit-O/pykg2vec/issues/186. Previously, users need to `cd` into the `examples` directory to run training, tuning and inferring codes. Now users can execute `pykg2vec-train`, `pykg2vec-tune` and `pykg2vec-infer` after installing the pykg2vec module (`pykg2vec-train.py`, `pykg2vec-tune.py` and `pykg2vec-infer.py` on Windows).

It is just the initial work and feedback are welcome based on the user experience.

